### PR TITLE
Update jwt.js - remove impersonation

### DIFF
--- a/examples/jwt.js
+++ b/examples/jwt.js
@@ -40,9 +40,7 @@ var authClient = new google.auth.JWT(
     // (do not use the path parameter above if using this param)
     'key',
     // Scopes can be specified either as an array or as a single, space-delimited string
-    ['https://www.googleapis.com/auth/drive.readonly'],
-    // User to impersonate (leave empty if no impersonation needed)
-    'subject-account-email@example.com');
+    ['https://www.googleapis.com/auth/drive.readonly']);
 
 authClient.authorize(function(err, tokens) {
   if (err) {


### PR DESCRIPTION
Removed user-impersonation email address after scopes in new JWT() call. Always resulted in "Error authorizing with JWT [Error: unauthorized_client]"

Without impersonation, use of Google Admin Reports API doesn't work though so there's likely an underlying issue that needs resolved. I will update if I find a solution there, but in the meantime, this change makes the example usable where impersonation isn't required.
